### PR TITLE
Fix two memory leaks et. al.

### DIFF
--- a/src/BlazorWorker.ServiceFactory/WorkerBackgroundServiceDependencies.cs
+++ b/src/BlazorWorker.ServiceFactory/WorkerBackgroundServiceDependencies.cs
@@ -1,16 +1,14 @@
-﻿using BlazorWorker.WorkerBackgroundService;
-using BlazorWorker.WorkerCore;
-using System.Linq;
+﻿using System.Linq;
 
 namespace BlazorWorker.BackgroundServiceFactory
 {
     internal class WorkerBackgroundServiceDependencies
     {
         public static string[] BlazorWorkerDependentAssemblyFilenames = new[] {
-            $"{typeof(BaseMessage).Assembly.GetName().Name}.dll",
-            $"{typeof(WorkerInstanceManager).Assembly.GetName().Name}.dll",
+            $"{typeof(Core.IWorker).Assembly.GetName().Name}.dll",
+            $"{typeof(WorkerCore.IWorkerMessageService).Assembly.GetName().Name}.dll",
+            $"{typeof(WorkerBackgroundService.WorkerInstanceManager).Assembly.GetName().Name}.dll",
             $"{typeof(Newtonsoft.Json.JsonConvert).Assembly.GetName().Name}.dll",
-            $"{typeof(IWorkerMessageService).Assembly.GetName().Name}.dll",
             $"{typeof(System.Reflection.Assembly).Assembly.GetName().Name}.dll",
         };
 

--- a/src/BlazorWorker/BlazorWorker.js
+++ b/src/BlazorWorker/BlazorWorker.js
@@ -5,8 +5,9 @@ window.BlazorWorker = function () {
 
         const worker = workers[workerId];
         if (worker) {
-            if (worker.worker.terminate)
+            if (worker.worker.terminate) {
                 worker.worker.terminate();
+            }
             URL.revokeObjectURL(worker.url);
             delete workers[workerId];
         }

--- a/src/BlazorWorker/BlazorWorker.js
+++ b/src/BlazorWorker/BlazorWorker.js
@@ -1,11 +1,13 @@
-﻿window.BlazorWorker = function () {
+window.BlazorWorker = function () {
     
     const workers = {};
     const disposeWorker = function (workerId) {
 
         const worker = workers[workerId];
-        if (worker && worker.terminate) {
-            worker.terminate();
+        if (worker) {
+            if (worker.worker.terminate)
+                worker.worker.terminate();
+            URL.revokeObjectURL(worker.url);
             delete workers[workerId];
         }
     };
@@ -193,8 +195,12 @@
         const renderedInlineWorker = inlineWorker.replace('$initConf$', renderedConfig);
         window.URL = window.URL || window.webkitURL;
         const blob = new Blob([renderedInlineWorker], { type: 'application/javascript' });
-        const worker = new Worker(URL.createObjectURL(blob));
-        workers[id] = worker;
+        const workerUrl = URL.createObjectURL(blob);
+        const worker = new Worker(workerUrl);
+        workers[id] = {
+            worker: worker,
+            url: workerUrl
+        };
 
         worker.onmessage = function (ev) {
             if (initOptions.debug) {
@@ -205,7 +211,7 @@
     };
 
     const postMessage = function (workerId, message) {
-        workers[workerId].postMessage(message);
+        workers[workerId].worker.postMessage(message);
     };
 
     return {

--- a/src/BlazorWorker/WorkerProxy.cs
+++ b/src/BlazorWorker/WorkerProxy.cs
@@ -1,4 +1,4 @@
-﻿using BlazorWorker.WorkerCore;
+using BlazorWorker.WorkerCore;
 using Microsoft.JSInterop;
 using System;
 using System.Threading.Tasks;
@@ -12,6 +12,7 @@ namespace BlazorWorker.Core
         private static long idSource;
         private bool isDisposed = false;
         private static readonly string messageMethod;
+        private readonly DotNetObjectReference<WorkerProxy> thisReference;
 
 
         public event EventHandler<string> IncomingMessage;
@@ -27,6 +28,7 @@ namespace BlazorWorker.Core
             this.jsRuntime = jsRuntime;
             this.scriptLoader = new ScriptLoader(this.jsRuntime);
             this.Identifier = ++idSource;
+            thisReference = DotNetObjectReference.Create(this);
         }
 
         public async ValueTask DisposeAsync()
@@ -34,6 +36,7 @@ namespace BlazorWorker.Core
             if (!isDisposed)
             {
                 await this.jsRuntime.InvokeVoidAsync("BlazorWorker.disposeWorker", this.Identifier);
+                thisReference.Dispose();
                 isDisposed = true;
             }
         }
@@ -45,7 +48,7 @@ namespace BlazorWorker.Core
             await this.jsRuntime.InvokeVoidAsync(
                 "BlazorWorker.initWorker", 
                 this.Identifier, 
-                DotNetObjectReference.Create(this), 
+                thisReference,
                 new WorkerInitOptions {
                     DependentAssemblyFilenames = 
                        WorkerProxyDependencies.DependentAssemblyFilenames,


### PR DESCRIPTION
Among other minor things, this PR fixes two memory leaks; one by calling `URL.revokeObjectURL` when a worker is disposed, and another by disposing `DotNetObjectReference`s in the `WorkerProxy` class.