### PR TITLE
Remove duplicate worker instantiation

### DIFF
--- a/src/BlazorWorker.Demo/SharedPages/Pages/BackgroundServiceMulti.razor
+++ b/src/BlazorWorker.Demo/SharedPages/Pages/BackgroundServiceMulti.razor
@@ -83,7 +83,7 @@
                         output += $"{rn}{LogDate()} Initializing a worker.";
                         StateHasChanged();
                         var worker = await workerFactory.CreateAsync();
-                        workers.Add(await workerFactory.CreateAsync());
+                        workers.Add(worker);
                         var service = await worker.CreateBackgroundServiceAsync<MathsService>();
                         backgroundServices.Add(service);
                         var progressRef = new ProgressRef();


### PR DESCRIPTION
It seems like the worker instantiated and saved to the variable "worker" is the one used to create the service, however, it is not the one added to the local list of workers. An unused NEW worker instance is instead added to the list. Effectively, each loop we create two worker instances, one in vain.