### PR TITLE
Enables a custom expression serializer, and…

### DIFF
--- a/src/BlazorWorker.Demo/Net8/Client/BlazorWorker.Demo.Client/Pages/ComplexSerialization.razor
+++ b/src/BlazorWorker.Demo/Net8/Client/BlazorWorker.Demo.Client/Pages/ComplexSerialization.razor
@@ -1,0 +1,2 @@
+﻿@page "/ComplexSerialization"
+<BlazorWorker.Demo.SharedPages.Pages.ComplexSerialization />

--- a/src/BlazorWorker.Demo/SharedPages/Pages/ComplexSerialization.razor
+++ b/src/BlazorWorker.Demo/SharedPages/Pages/ComplexSerialization.razor
@@ -83,12 +83,12 @@
             }
             if (backgroundService == null)
             {
-                
+
                 output += $"Starting BackgroundService...{rn}";
                 await this.InvokeAsync(StateHasChanged);
                 /* 
-                 * have a look here. This is the essence of this example.
-                 * */
+                * have a look here. This is the essence of this example.
+                * */
 
                 backgroundService = await worker.CreateBackgroundServiceAsync<ComplexService>(options 
                     => options.UseCustomExpressionSerializer(typeof(CustomSerializeLinqExpressionJsonSerializer)));
@@ -111,8 +111,9 @@
                 };
 
             var result = await backgroundService.RunAsync(service => service.ComplexCall(complexArgInstance));
-
+            var elapsed = sw.ElapsedMilliseconds;
             output += $"{rn}result: " + System.Text.Json.JsonSerializer.Serialize(result);
+            output += $"{rn}roundtrip to worker in {elapsed}ms";
         }
         catch (Exception e)
         {
@@ -121,7 +122,7 @@
         finally
         {
             Running = false;
-            output += $"{rn}Done."
+            output += $"{rn}Done.";
         }
     }
 

--- a/src/BlazorWorker.Demo/SharedPages/Pages/ComplexSerialization.razor
+++ b/src/BlazorWorker.Demo/SharedPages/Pages/ComplexSerialization.razor
@@ -1,0 +1,132 @@
+﻿@inject IWorkerFactory workerFactory
+
+@using BlazorWorker.BackgroundServiceFactory
+@using BlazorWorker.WorkerBackgroundService 
+@using BlazorWorker.Demo.Shared
+@using BlazorWorker.Core
+    <div class="row">
+        <div class="col-6 col-xs-12">
+            <h1>.NET Worker Multithreading</h1>
+
+            Complex / Custom Serialization <br />
+            <br /><br />
+            <button @onclick="OnClick" class="btn btn-primary">Run Test</button><br />
+
+            <br />
+            <br />
+            <strong>Output:</strong>
+            <hr />
+<pre>
+@output
+</pre>
+        </div>
+        <div class="col-6 col-xs-12">
+            <GithubSource RelativePath="Pages/BackgroundServiceMulti.razor" />
+        </div>
+        </div>
+@code {
+
+    string output;
+
+    IWorker worker;
+    IWorkerBackgroundService<ComplexService> backgroundService;
+
+    string RunDisabled => Running ? "disabled" : null;
+    bool Running = false;
+
+
+    public class ComplexService
+    {
+        public ComplexServiceResponse ComplexCall(ComplexServiceArg arg)
+        {
+            return new ComplexServiceResponse
+            {
+                OriginalArg = arg,
+                OnlyInResponse = "This is only in response."
+            };
+        }
+    }
+
+    public class ComplexServiceArg
+    {
+        public string ThisIsJustAString { get; set; }
+        public OhLookARecord ARecord { get; set; }
+        public Dictionary<string, string> ADictionary { get; set; }
+        public ComplexServiceArg TypeRecursive { get; set; }
+    }
+
+    public class ComplexServiceResponse
+    {
+        public ComplexServiceArg OriginalArg { get; set; }
+        public string OnlyInResponse { get; set; }
+    }
+
+    public record OhLookARecord
+    {
+        public int Number { get; set; }
+    }
+
+    public async Task OnClick(EventArgs _)
+    {
+        Running = true;
+        await this.InvokeAsync(StateHasChanged);
+
+        output = "";
+        var rn = Environment.NewLine;
+        try
+        {
+            if (worker == null)
+            {
+                output += $"Starting worker...{rn}";
+                await this.InvokeAsync(StateHasChanged);
+                worker = await workerFactory.CreateAsync();
+            }
+            if (backgroundService == null)
+            {
+                
+                output += $"Starting BackgroundService...{rn}";
+                await this.InvokeAsync(StateHasChanged);
+                /* 
+                 * have a look here. This is the essence of this example.
+                 * */
+
+                backgroundService = await worker.CreateBackgroundServiceAsync<ComplexService>(options 
+                    => options.UseCustomExpressionSerializer(typeof(CustomSerializeLinqExpressionJsonSerializer)));
+            }
+
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+
+            var complexArgInstance = new ComplexServiceArg
+                {
+                    ThisIsJustAString = "just a string",
+                    ARecord = new OhLookARecord { Number = 5 },
+                    ADictionary = new Dictionary<string, string>
+                    {
+                        { "Test", "TestValue" } 
+                    },
+                    TypeRecursive = new ComplexServiceArg
+                    {
+                        ThisIsJustAString = "SubString"
+                    }
+                };
+
+            var result = await backgroundService.RunAsync(service => service.ComplexCall(complexArgInstance));
+
+            output += $"{rn}result: " + System.Text.Json.JsonSerializer.Serialize(result);
+        }
+        catch (Exception e)
+        {
+            output += $"{rn}Error = {e}";
+        }
+        finally
+        {
+            Running = false;
+            output += $"{rn}Done."
+        }
+    }
+
+    private string LogDate()
+    {
+        return DateTime.Now.ToString("HH:mm:ss:fff");
+    }
+}

--- a/src/BlazorWorker.Demo/SharedPages/Shared/CustomExpressionSerializer.cs
+++ b/src/BlazorWorker.Demo/SharedPages/Shared/CustomExpressionSerializer.cs
@@ -1,0 +1,47 @@
+﻿using BlazorWorker.WorkerBackgroundService;
+using Serialize.Linq.Serializers;
+using System;
+using System.Linq.Expressions;
+using static BlazorWorker.Demo.SharedPages.Pages.ComplexSerialization;
+
+namespace BlazorWorker.Demo.SharedPages.Shared
+{
+    /// <summary>
+    /// Custom expression Serializer using <see cref="Serialize.Linq.ExpressionSerializer"/> 
+    /// as base class, but explicitly adds complex types as known types.
+    /// </summary>
+    public class CustomSerializeLinqExpressionJsonSerializer : SerializeLinqExpressionJsonSerializerBase
+    {
+        public override Type[] GetKnownTypes() => 
+            [typeof(ComplexServiceArg), typeof(ComplexServiceResponse), typeof(OhLookARecord)];
+    }
+
+    /// <summary>
+    /// Fully custom Expression Serializer, which uses <see cref="Serialize.Linq.ExpressionSerializer"/> but you could use an alternative implementation.
+    /// </summary>
+    public class CustomExpressionSerializer : IExpressionSerializer
+    {
+        private readonly ExpressionSerializer serializer;
+
+        public CustomExpressionSerializer()
+        {
+            var specificSerializer = new JsonSerializer();
+            specificSerializer.AddKnownType(typeof(ComplexServiceArg));
+            specificSerializer.AddKnownType(typeof(ComplexServiceResponse));
+            specificSerializer.AddKnownType(typeof(OhLookARecord));
+
+            this.serializer = new ExpressionSerializer(specificSerializer);
+        }
+
+        public Expression Deserialize(string expressionString)
+        {
+            return serializer.DeserializeText(expressionString);
+        }
+
+        public string Serialize(Expression expression)
+        {
+            return serializer.SerializeText(expression);
+        }
+    }
+
+}

--- a/src/BlazorWorker.Demo/SharedPages/Shared/CustomExpressionSerializer.cs
+++ b/src/BlazorWorker.Demo/SharedPages/Shared/CustomExpressionSerializer.cs
@@ -7,7 +7,7 @@ using static BlazorWorker.Demo.SharedPages.Pages.ComplexSerialization;
 namespace BlazorWorker.Demo.SharedPages.Shared
 {
     /// <summary>
-    /// Custom expression Serializer using <see cref="Serialize.Linq.ExpressionSerializer"/> 
+    /// Example 1: Simple custom expression Serializer using <see cref="Serialize.Linq.ExpressionSerializer"/> 
     /// as base class, but explicitly adds complex types as known types.
     /// </summary>
     public class CustomSerializeLinqExpressionJsonSerializer : SerializeLinqExpressionJsonSerializerBase

--- a/src/BlazorWorker.Demo/SharedPages/Shared/NavMenuLinksModel.cs
+++ b/src/BlazorWorker.Demo/SharedPages/Shared/NavMenuLinksModel.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using BlazorWorker.Demo.SharedPages.Pages;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
 using System;
 using System.Collections.Generic;
@@ -34,6 +35,10 @@ namespace BlazorWorker.Demo.SharedPages.Shared
             {
                 new() { Icon = "document", Href="IndexedDB", Text = "IndexedDB" }
             },
+            {
+                new() { Icon = "document", Href="ComplexSerialization", Text = "ComplexSerialization" }
+            },
+            
             {
                 new() { Icon = "fork", Href="https://github.com/tewr/BlazorWorker", Text = "To the source!" }
             },

--- a/src/BlazorWorker.ServiceFactory/BlazorWorker.BackgroundServiceFactory.xml
+++ b/src/BlazorWorker.ServiceFactory/BlazorWorker.BackgroundServiceFactory.xml
@@ -30,5 +30,14 @@
             Attached objects, notably parent worker proxy which may have been created without consumer being directly able to dispose
             </summary>
         </member>
+        <member name="M:BlazorWorker.BackgroundServiceFactory.WorkerInitExtension.UseCustomExpressionSerializer(BlazorWorker.Core.WorkerInitOptions,System.Type)">
+            <summary>
+            Sets a custom ExpressionSerializer.
+            </summary>
+            <param name="source"></param>
+            <param name="expressionSerializerType">A type that implements <see cref="T:BlazorWorker.WorkerBackgroundService.IExpressionSerializer"/></param>
+            <returns></returns>
+            <exception cref="T:System.ArgumentNullException"></exception>
+        </member>
     </members>
 </doc>

--- a/src/BlazorWorker.ServiceFactory/BlazorWorker.BackgroundServiceFactory.xml
+++ b/src/BlazorWorker.ServiceFactory/BlazorWorker.BackgroundServiceFactory.xml
@@ -32,7 +32,7 @@
         </member>
         <member name="M:BlazorWorker.BackgroundServiceFactory.WorkerInitExtension.UseCustomExpressionSerializer(BlazorWorker.Core.WorkerInitOptions,System.Type)">
             <summary>
-            Sets a custom ExpressionSerializer.
+            Sets a custom ExpressionSerializer type. Must implement <see cref="T:BlazorWorker.WorkerBackgroundService.IExpressionSerializer"/>..
             </summary>
             <param name="source"></param>
             <param name="expressionSerializerType">A type that implements <see cref="T:BlazorWorker.WorkerBackgroundService.IExpressionSerializer"/></param>

--- a/src/BlazorWorker.ServiceFactory/WorkerBackgroundServiceExtensions.cs
+++ b/src/BlazorWorker.ServiceFactory/WorkerBackgroundServiceExtensions.cs
@@ -26,12 +26,19 @@ namespace BlazorWorker.BackgroundServiceFactory
             {
                 throw new ArgumentNullException(nameof(webWorkerProxy));
             }
-
-            var proxy = new WorkerBackgroundServiceProxy<T>(webWorkerProxy, new WebWorkerOptions());
             if (workerInitOptions == null)
             {
                 workerInitOptions = new WorkerInitOptions();
             }
+
+            var webWorkerOptions = new WebWorkerOptions();
+            if (workerInitOptions.EnvMap?.TryGetValue(WebWorkerOptions.ExpressionSerializerTypeEnvKey, out var serializerType) == true)
+            {
+                webWorkerOptions.ExpressionSerializerType = Type.GetType(serializerType);
+            }
+
+            var proxy = new WorkerBackgroundServiceProxy<T>(webWorkerProxy, webWorkerOptions);
+
 
             await proxy.InitAsync(workerInitOptions);
             return proxy;
@@ -68,7 +75,19 @@ namespace BlazorWorker.BackgroundServiceFactory
             {
                 workerInitOptionsModifier(workerInitOptions);
             }
-            var factoryProxy = new WorkerBackgroundServiceProxy<TFactory>(webWorkerProxy, new WebWorkerOptions());
+
+            if (workerInitOptions == null)
+            {
+                workerInitOptions = new WorkerInitOptions();
+            }
+
+            var webWorkerOptions = new WebWorkerOptions();
+            if (workerInitOptions.EnvMap?.TryGetValue(WebWorkerOptions.ExpressionSerializerTypeEnvKey, out var serializerType) == true)
+            {
+                webWorkerOptions.ExpressionSerializerType = Type.GetType(serializerType);
+            }
+
+            var factoryProxy = new WorkerBackgroundServiceProxy<TFactory>(webWorkerProxy, webWorkerOptions);
             await factoryProxy.InitAsync(workerInitOptions);
 
             var newProxy = await factoryProxy.InitFromFactoryAsync(factoryExpression);

--- a/src/BlazorWorker.ServiceFactory/WorkerBackgroundServiceExtensions.cs
+++ b/src/BlazorWorker.ServiceFactory/WorkerBackgroundServiceExtensions.cs
@@ -32,10 +32,7 @@ namespace BlazorWorker.BackgroundServiceFactory
             }
 
             var webWorkerOptions = new WebWorkerOptions();
-            if (workerInitOptions.EnvMap?.TryGetValue(WebWorkerOptions.ExpressionSerializerTypeEnvKey, out var serializerType) == true)
-            {
-                webWorkerOptions.ExpressionSerializerType = Type.GetType(serializerType);
-            }
+            webWorkerOptions.SetExpressionSerializerFromInitOptions(workerInitOptions);
 
             var proxy = new WorkerBackgroundServiceProxy<T>(webWorkerProxy, webWorkerOptions);
 
@@ -82,10 +79,8 @@ namespace BlazorWorker.BackgroundServiceFactory
             }
 
             var webWorkerOptions = new WebWorkerOptions();
-            if (workerInitOptions.EnvMap?.TryGetValue(WebWorkerOptions.ExpressionSerializerTypeEnvKey, out var serializerType) == true)
-            {
-                webWorkerOptions.ExpressionSerializerType = Type.GetType(serializerType);
-            }
+            webWorkerOptions.SetExpressionSerializerFromInitOptions(workerInitOptions);
+            
 
             var factoryProxy = new WorkerBackgroundServiceProxy<TFactory>(webWorkerProxy, webWorkerOptions);
             await factoryProxy.InitAsync(workerInitOptions);
@@ -93,6 +88,14 @@ namespace BlazorWorker.BackgroundServiceFactory
             var newProxy = await factoryProxy.InitFromFactoryAsync(factoryExpression);
             newProxy.Disposables.Add(factoryProxy);
             return newProxy;
+        }
+
+        private static void SetExpressionSerializerFromInitOptions(this WebWorkerOptions target, WorkerInitOptions workerInitOptions)
+        {
+            if (workerInitOptions.EnvMap?.TryGetValue(WebWorkerOptions.ExpressionSerializerTypeEnvKey, out var serializerType) == true)
+            {
+                target.ExpressionSerializerType = Type.GetType(serializerType);
+            }
         }
 
         /// <summary>

--- a/src/BlazorWorker.ServiceFactory/WorkerInitExtension.cs
+++ b/src/BlazorWorker.ServiceFactory/WorkerInitExtension.cs
@@ -1,0 +1,32 @@
+﻿using BlazorWorker.Core;
+using BlazorWorker.WorkerBackgroundService;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlazorWorker.BackgroundServiceFactory
+{
+    public static class WorkerInitExtension
+    {
+
+        /// <summary>
+        /// Sets a custom ExpressionSerializer type. Must implement <see cref="IExpressionSerializer"/>..
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="expressionSerializerType">A type that implements <see cref="IExpressionSerializer"/></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static WorkerInitOptions UseCustomExpressionSerializer(this WorkerInitOptions source, Type expressionSerializerType)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            source.SetEnv(WebWorkerOptions.ExpressionSerializerTypeEnvKey, expressionSerializerType.AssemblyQualifiedName);
+            return source;
+        }
+    }
+}

--- a/src/BlazorWorker.ServiceFactory/WorkerInitExtension.cs
+++ b/src/BlazorWorker.ServiceFactory/WorkerInitExtension.cs
@@ -1,10 +1,6 @@
 ﻿using BlazorWorker.Core;
 using BlazorWorker.WorkerBackgroundService;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BlazorWorker.BackgroundServiceFactory
 {

--- a/src/BlazorWorker.WorkerBackgroundService/BlazorWorker.WorkerBackgroundService.xml
+++ b/src/BlazorWorker.WorkerBackgroundService/BlazorWorker.WorkerBackgroundService.xml
@@ -54,6 +54,11 @@
             Unregisters the event corresponding to the specified <paramref name="handle"/>
             </summary>
         </member>
+        <member name="F:BlazorWorker.WorkerBackgroundService.WebWorkerOptions.ExpressionSerializerTypeEnvKey">
+            <summary>
+            Name of environment variable to be used for transferring the serializer typename
+            </summary>
+        </member>
         <member name="M:BlazorWorker.WorkerBackgroundService.WebWorkerOptions.ValidateExpressionSerializerType(System.Type)">
             <summary>
             Ensures that the provided type implements <see cref="T:BlazorWorker.WorkerBackgroundService.IExpressionSerializer"/>

--- a/src/BlazorWorker.WorkerBackgroundService/BlazorWorker.WorkerBackgroundService.xml
+++ b/src/BlazorWorker.WorkerBackgroundService/BlazorWorker.WorkerBackgroundService.xml
@@ -54,5 +54,12 @@
             Unregisters the event corresponding to the specified <paramref name="handle"/>
             </summary>
         </member>
+        <member name="M:BlazorWorker.WorkerBackgroundService.WebWorkerOptions.ValidateExpressionSerializerType(System.Type)">
+            <summary>
+            Ensures that the provided type implements <see cref="T:BlazorWorker.WorkerBackgroundService.IExpressionSerializer"/>
+            </summary>
+            <param name="sourceType"></param>
+            <returns></returns>
+        </member>
     </members>
 </doc>

--- a/src/BlazorWorker.WorkerBackgroundService/SerializeLinqExpressionJsonSerializerBase.cs
+++ b/src/BlazorWorker.WorkerBackgroundService/SerializeLinqExpressionJsonSerializerBase.cs
@@ -4,6 +4,9 @@ using System.Linq.Expressions;
 
 namespace BlazorWorker.WorkerBackgroundService
 {
+    /// <summary>
+    /// Base class for adding known types to a serializer using <see cref="Serialize.Linq.Serializers.JsonSerializer"/>.
+    /// </summary>
     public abstract class SerializeLinqExpressionJsonSerializerBase : IExpressionSerializer
     {
         private ExpressionSerializer serializer;
@@ -11,7 +14,14 @@ namespace BlazorWorker.WorkerBackgroundService
         private ExpressionSerializer Serializer
             => this.serializer ?? (this.serializer = GetSerializer());
 
+        /// <summary>
+        /// Automatically adds known types as array types. If set to <c>true</c>, sets <see cref="AutoAddKnownTypesAsListTypes"/> to <c>false</c>.
+        /// </summary>
         public bool? AutoAddKnownTypesAsArrayTypes { get; set; }
+
+        /// <summary>
+        /// Automatically adds known types as list types. If set to <c>true</c>, sets <see cref="AutoAddKnownTypesAsArrayTypes"/> to <c>false</c>.
+        /// </summary>
         public bool? AutoAddKnownTypesAsListTypes { get; set; }
 
         public abstract Type[] GetKnownTypes();

--- a/src/BlazorWorker.WorkerBackgroundService/SerializeLinqExpressionJsonSerializerBase.cs
+++ b/src/BlazorWorker.WorkerBackgroundService/SerializeLinqExpressionJsonSerializerBase.cs
@@ -1,0 +1,47 @@
+﻿using Serialize.Linq.Serializers;
+using System;
+using System.Linq.Expressions;
+
+namespace BlazorWorker.WorkerBackgroundService
+{
+    public abstract class SerializeLinqExpressionJsonSerializerBase : IExpressionSerializer
+    {
+        private ExpressionSerializer serializer;
+
+        private ExpressionSerializer Serializer
+            => this.serializer ?? (this.serializer = GetSerializer());
+
+        public bool? AutoAddKnownTypesAsArrayTypes { get; set; }
+        public bool? AutoAddKnownTypesAsListTypes { get; set; }
+
+        public abstract Type[] GetKnownTypes();
+
+        private ExpressionSerializer GetSerializer()
+        {
+            var jsonSerializer = new JsonSerializer();
+            foreach (var type in GetKnownTypes())
+            {
+                jsonSerializer.AddKnownType(type);
+            }
+            if (this.AutoAddKnownTypesAsArrayTypes.HasValue) {
+                jsonSerializer.AutoAddKnownTypesAsArrayTypes = this.AutoAddKnownTypesAsArrayTypes.Value; 
+            }
+            if (this.AutoAddKnownTypesAsListTypes.HasValue)
+            {
+                jsonSerializer.AutoAddKnownTypesAsListTypes = this.AutoAddKnownTypesAsListTypes.Value;
+            }
+
+            return new ExpressionSerializer(jsonSerializer);
+        }
+
+        public Expression Deserialize(string expressionString)
+        {
+            return this.Serializer.DeserializeText(expressionString);
+        }
+
+        public string Serialize(Expression expression)
+        {
+            return this.Serializer.SerializeText(expression);
+        }
+    }
+}

--- a/src/BlazorWorker.WorkerBackgroundService/WebWorkerOptions.cs
+++ b/src/BlazorWorker.WorkerBackgroundService/WebWorkerOptions.cs
@@ -1,18 +1,62 @@
-﻿namespace BlazorWorker.WorkerBackgroundService
+﻿using System;
+
+namespace BlazorWorker.WorkerBackgroundService
 {
     public class WebWorkerOptions
     {
+        public static readonly string ExpressionSerializerTypeEnvKey = "BLAZORWORKER_EXPRESSIONSERIALIZER";
+
         private ISerializer messageSerializer;
         private IExpressionSerializer expressionSerializer;
+        private Type expressionSerializerType;
+
+
 
         public ISerializer MessageSerializer { 
             get => messageSerializer ?? (messageSerializer = new DefaultMessageSerializer()); 
             set => messageSerializer = value; 
         }
 
-        public IExpressionSerializer ExpressionSerializer { 
-            get => expressionSerializer ?? (expressionSerializer = new SerializeLinqExpressionSerializer()) ; 
+        public IExpressionSerializer ExpressionSerializer {
+            get => expressionSerializer ?? (expressionSerializer = CreateSerializerInstance()); 
             set => expressionSerializer = value; 
+        }
+
+        public Type ExpressionSerializerType
+        {
+            get => expressionSerializerType ?? typeof(SerializeLinqExpressionSerializer);
+            set => expressionSerializerType = ValidateExpressionSerializerType(value);
+        }
+
+        /// <summary>
+        /// Ensures that the provided type implements <see cref="IExpressionSerializer"/>
+        /// </summary>
+        /// <param name="sourceType"></param>
+        /// <returns></returns>
+        private Type ValidateExpressionSerializerType(Type sourceType)
+        {
+            if (sourceType == null)
+            {
+                return null;
+            }
+
+            if (!sourceType.IsClass)
+            {
+                throw new Exception($"The {nameof(ExpressionSerializerType)} '{sourceType.AssemblyQualifiedName}' must be a class.");
+            }
+
+            if (!typeof(IExpressionSerializer).IsAssignableFrom(sourceType))
+            {
+                throw new Exception($"The {nameof(ExpressionSerializerType)} '{sourceType.AssemblyQualifiedName}' must be assignable to {nameof(IExpressionSerializer)}");
+            }
+
+            return sourceType;
+        }
+
+        private IExpressionSerializer CreateSerializerInstance()
+        {
+            var instance = Activator.CreateInstance(ExpressionSerializerType);
+            return (IExpressionSerializer)instance;
         }
     }
 }

--- a/src/BlazorWorker.WorkerBackgroundService/WebWorkerOptions.cs
+++ b/src/BlazorWorker.WorkerBackgroundService/WebWorkerOptions.cs
@@ -4,6 +4,9 @@ namespace BlazorWorker.WorkerBackgroundService
 {
     public class WebWorkerOptions
     {
+        /// <summary>
+        /// Name of environment variable to be used for transferring the serializer typename
+        /// </summary>
         public static readonly string ExpressionSerializerTypeEnvKey = "BLAZORWORKER_EXPRESSIONSERIALIZER";
 
         private ISerializer messageSerializer;

--- a/src/BlazorWorker.WorkerBackgroundService/WorkerInstanceManager.cs
+++ b/src/BlazorWorker.WorkerBackgroundService/WorkerInstanceManager.cs
@@ -40,6 +40,11 @@ namespace BlazorWorker.WorkerBackgroundService
         {
             this.serializer = new DefaultMessageSerializer();
             this.options = new WebWorkerOptions();
+            var expressionSerializerType = Environment.GetEnvironmentVariable(WebWorkerOptions.ExpressionSerializerTypeEnvKey);
+            if (expressionSerializerType != null)
+            {
+                this.options.ExpressionSerializerType = Type.GetType(expressionSerializerType);
+            }
             this.simpleInstanceService = SimpleInstanceService.Instance;
 
             this.messageHandler = messageHandlerRegistry.GetRegistryForInstance(this);

--- a/src/BlazorWorker.WorkerBackgroundService/WorkerInstanceManager.cs
+++ b/src/BlazorWorker.WorkerBackgroundService/WorkerInstanceManager.cs
@@ -13,12 +13,12 @@ namespace BlazorWorker.WorkerBackgroundService
     public partial class WorkerInstanceManager
     {
         private readonly ConcurrentDictionary<long, IEventWrapper> events =
-             new ConcurrentDictionary<long, IEventWrapper>();
+             new();
 
         private static readonly MessageHandlerRegistry<WorkerInstanceManager> messageHandlerRegistry
-            = new MessageHandlerRegistry<WorkerInstanceManager>(wim => wim.serializer);
+            = new(wim => wim.serializer);
 
-        public static readonly WorkerInstanceManager Instance = new WorkerInstanceManager();
+        public static readonly WorkerInstanceManager Instance = new();
 
         internal readonly ISerializer serializer;
         private readonly WebWorkerOptions options;
@@ -45,6 +45,7 @@ namespace BlazorWorker.WorkerBackgroundService
             {
                 this.options.ExpressionSerializerType = Type.GetType(expressionSerializerType);
             }
+            
             this.simpleInstanceService = SimpleInstanceService.Instance;
 
             this.messageHandler = messageHandlerRegistry.GetRegistryForInstance(this);

--- a/src/BlazorWorker.WorkerCore/InitOptions.cs
+++ b/src/BlazorWorker.WorkerCore/InitOptions.cs
@@ -14,7 +14,7 @@ namespace BlazorWorker.Core
         /// </summary>
         public WorkerInitOptions()
         {
-            DependentAssemblyFilenames = new string[] { };
+            DependentAssemblyFilenames = [];
 
 #if NETSTANDARD21
             DeployPrefix = "_framework/_bin";
@@ -49,7 +49,7 @@ namespace BlazorWorker.Core
         public string DeployPrefix { get; }
 
         /// <summary>
-        /// Specifieds the location of the wasm binary
+        /// Specifies the location of the wasm binary
         /// </summary>
         public string WasmRoot { get; }
 
@@ -70,7 +70,7 @@ namespace BlazorWorker.Core
         public MethodIdentifier MessageEndPoint { get; set; }
 
         /// <summary>
-        /// Mono-wasm-annotated endpoint for instanciating the worker. Experts only.
+        /// Mono-wasm-annotated endpoint for instantiating the worker. Experts only.
         /// </summary>
         public MethodIdentifier InitEndPoint { get; set; }
 
@@ -119,10 +119,6 @@ namespace BlazorWorker.Core
             return new WorkerInitOptions
             {
                 CallbackMethod = initOptions.CallbackMethod ?? this.CallbackMethod,
-                /*DependentAssemblyFilenames = this.DependentAssemblyFilenames
-                    .Concat(initOptions.DependentAssemblyFilenames)
-                    .Distinct()
-                    .ToArray(),*/
                 UseConventionalServiceAssembly = initOptions.UseConventionalServiceAssembly,
                 MessageEndPoint = initOptions.MessageEndPoint ?? this.MessageEndPoint,
                 InitEndPoint = initOptions.InitEndPoint ?? this.InitEndPoint,
@@ -139,7 +135,7 @@ namespace BlazorWorker.Core
     {
 
         /// <summary>
-        /// Adds the specified assembly filesnames as dependencies
+        /// Adds the specified assembly filenames as dependencies
         /// </summary>
         /// <param name="source"></param>
         /// <param name="dependentAssemblyFilenames"></param>
@@ -160,7 +156,6 @@ namespace BlazorWorker.Core
         [Obsolete("Manual dependency optimization is silently ignored in this version of BlazorWorker.")]
         public static WorkerInitOptions AddConventionalAssemblyOfService(this WorkerInitOptions source)
         {
-            source.UseConventionalServiceAssembly = true;
             return source;
         }
 
@@ -172,7 +167,7 @@ namespace BlazorWorker.Core
         [Obsolete("Manual dependency optimization is silently ignored in this version of BlazorWorker.")]
         public static WorkerInitOptions AddAssemblyOf<T>(this WorkerInitOptions source)
         {
-            return source.AddAssemblyOfType(typeof(T));
+            return source;
         }
 
         /// <summary>
@@ -184,12 +179,11 @@ namespace BlazorWorker.Core
         [Obsolete("Manual dependency optimization is silently ignored in this version of BlazorWorker.")]
         public static WorkerInitOptions AddAssemblyOfType(this WorkerInitOptions source, Type type)
         {
-            source.AddAssemblies($"{type.Assembly.GetName().Name}.dll");
             return source;
         }
 
         /// <summary>
-        /// Registers the neccessary dependencies for injecting or instanciating <see cref="System.Net.Http.HttpClient"/> in the background service.
+        /// Registers the necessary dependencies for injecting or instantiating <see cref="System.Net.Http.HttpClient"/> in the background service.
         /// </summary>
         /// <param name="source"></param>
         /// <returns></returns>
@@ -197,21 +191,6 @@ namespace BlazorWorker.Core
         [Obsolete("Manual dependency optimization is silently ignored in this version of BlazorWorker.")]
         public static WorkerInitOptions AddHttpClient(this WorkerInitOptions source)
         {
-#if NETSTANDARD21
-            source.AddAssemblies("System.Net.Http.dll", "System.Net.Http.WebAssemblyHttpHandler.dll");
-#endif
-
-#if NET5_0_OR_GREATER
-            source.AddAssemblies(
-                "System.Net.Http.dll", 
-                "System.Security.Cryptography.X509Certificates.dll",
-                "System.Net.Primitives.dll",
-                "System.Net.Requests.dll",
-                "System.Net.Security.dll",
-                "System.Net.dll",
-                "System.Diagnostics.Tracing.dll");
-#endif
-
             return source;
         }
 


### PR DESCRIPTION
… also a baseclass for just adding known types to the Serialize.Linq JsonSerializer. Really the same goal as #73 but stays away from modifying `BlazorWorker.Core`, as core should not deal with types or serialization.  Draft for resolving #27 . 