### PR TITLE
add option to set approot in init options

### DIFF
--- a/src/BlazorWorker.WorkerCore/BlazorWorker.WorkerCore.xml
+++ b/src/BlazorWorker.WorkerCore/BlazorWorker.WorkerCore.xml
@@ -38,6 +38,11 @@
             Creates a new instance of WorkerInitOptions
             </summary>
         </member>
+        <member name="P:BlazorWorker.Core.WorkerInitOptions.AppRoot">
+            <summary>
+            Set's the path to the wwwroot directory
+            </summary>
+        </member>
         <member name="P:BlazorWorker.Core.WorkerInitOptions.DeployPrefix">
             <summary>
             Specifies the location of binaries

--- a/src/BlazorWorker.WorkerCore/InitOptions.cs
+++ b/src/BlazorWorker.WorkerCore/InitOptions.cs
@@ -47,6 +47,11 @@ namespace BlazorWorker.Core
         }
 
         /// <summary>
+        /// Set's the path to the wwwroot directory
+        /// </summary>
+        public string AppRoot { get; set; }
+
+        /// <summary>
         /// Specifies the location of binaries
         /// </summary>
         public string DeployPrefix { get; }
@@ -87,14 +92,14 @@ namespace BlazorWorker.Core
         public Dictionary<string, bool> RuntimePreprocessorSymbols { get; set; }
 
         /// <summary>
-        /// Sets environment variables in the target worker. 
+        /// Sets environment variables in the target worker.
         /// </summary>
         /// <remarks>
         /// Defaults to a single entry: DOTNET_SYSTEM_GLOBALIZATION_INVARIANT = '0'.
         /// For more information see https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables
         /// </remarks>
-        public Dictionary<string, string> EnvMap { get; set; } 
-            = new Dictionary<string, string>() { 
+        public Dictionary<string, string> EnvMap { get; set; }
+            = new Dictionary<string, string>() {
                 { "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "0" },
             };
 
@@ -110,6 +115,7 @@ namespace BlazorWorker.Core
             }
             return new WorkerInitOptions
             {
+                AppRoot = initOptions.AppRoot ?? this.AppRoot,
                 CallbackMethod = initOptions.CallbackMethod ?? this.CallbackMethod,
                 MessageEndPoint = initOptions.MessageEndPoint ?? this.MessageEndPoint,
                 InitEndPoint = initOptions.InitEndPoint ?? this.InitEndPoint,

--- a/src/BlazorWorker/BlazorWorker.js
+++ b/src/BlazorWorker/BlazorWorker.js
@@ -235,7 +235,12 @@ window.BlazorWorker = function () {
     const inlineWorker = `self.onmessage = ${workerDef}()`; 
 
     const initWorker = function (id, callbackInstance, initOptions) {
-        let appRoot = (document.getElementsByTagName('base')[0] || { href: window.location.origin }).href || "";
+        let appRoot = initOptions.appRoot;
+
+        if (!appRoot) {
+            appRoot = (document.getElementsByTagName('base')[0] || { href: window.location.origin }).href || "";
+        }
+
         if (appRoot.endsWith("/")) {
             appRoot = appRoot.substring(0, appRoot.length - 1);
         }


### PR DESCRIPTION
We are using Blazor with CustomElements which means we can't use a base element to set the approot for BlazorWorker.
This PR adds the option, to set the approot via. the init options